### PR TITLE
And the other missing import for the broken cert case

### DIFF
--- a/brm_rest_walk/brm_rest_walk.py
+++ b/brm_rest_walk/brm_rest_walk.py
@@ -2,6 +2,7 @@
 # pylint: disable=expression-not-assigned,line-too-long
 """Walk the REST accessible path tree of some binary repository management system."""
 import datetime as dti
+import warnings
 
 import requests
 from requests.packages.urllib3.exceptions import InsecureRequestWarning


### PR DESCRIPTION
This is not elegant and it reverts the requests base alert paradigm - another PR should make this clumsy silencing optional